### PR TITLE
Match Cellpose's preprocessing contract: disable sopa's CLAHE and gaussian

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Cellpose preprocessing now matches Cellpose's own contract: sopa's gaussian
+  filter and CLAHE are both disabled.** Cellpose normalises by rescaling to the 1st
+  and 99th percentiles and does nothing else — it contains no CLAHE code, and
+  Cellpose-SAM was trained on exactly that normalisation. sopa layered two extra
+  stages on top of every patch: `gaussian_filter(sigma=1)` and
+  `equalize_adapthist(clip_limit=0.2)`. New params `cellpose_clip_limit` (`0`),
+  `cellpose_gaussian_sigma` (`0`), `cellpose_clahe_kernel_size` (`null`) and
+  `cellpose_tile_norm_blocksize` (`0`, Cellpose's own default) control them; restore
+  the old behaviour with `--cellpose_clip_limit 0.2 --cellpose_gaussian_sigma 1`.
+
+  Both stages were computed per patch, and CLAHE's kernel is `patch.shape // 8`, so
+  the contrast-enhancement scale tracked `patch_width_pixel` — at COMET's 0.28 µm/px,
+  52 µm at 1500 px, 105 µm at 3000 and 210 µm at 6000 for identical tissue. Measured
+  on a real COMET image, segmenting the same region as part of a 1500 px vs a 3000 px
+  patch and matching cells by IoU, the fraction of cell boundaries surviving a
+  patch-size change (IoU ≥ 0.90) went from 38.6% to 81.9% for `cpsam_v2`, 43.2% to
+  83.9% for `cpsam` and 36.8% to 86.6% for `cpdino`.
+
+  **This changes results and they should not be pooled with earlier runs.** Median
+  cell area falls 23–43% for every model, and cell counts move by +8–35%
+  (`cpsam_v2`), −3–10% (`cpsam`) and +28–54% (`cpdino`) — CLAHE was suppressing
+  detections in the newer models and inflating them in `cpsam`. `cellpose_diameter`
+  needs no adjustment: Cellpose-SAM trained across 0.25×–4× scale, so the smaller
+  cells sit well inside its range.
+
+  Verified end to end on the `test` profile (30 tasks, nine-patch path), and run on a
+  COMET brain-panel ROI with `cpsam_v2`, `cpdino` and cellSAM then inspected in
+  QuPath — all three sensible and closely comparable (1,742 / 1,751 / 1,648 cells),
+  with cellSAM drawing larger boundaries around membrane signal.
+
+  These numbers measure reproducibility, not accuracy; no annotations were scored,
+  and the normalisation measurements are DAPI-only. See
+  [docs/usage.md](docs/usage.md) for the full reasoning.
+
 - **Cellpose is upgraded to 4.2.1.1 and now runs on the GPU.** The container
   moves to a Wave build carrying sopa 2.2.6, cellpose 4.2.1.1 and Meta's
   `dinov3`, replacing `sopa:2.1.11-cellpose` (cellpose 4.0.8). Segmentation

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -92,6 +92,23 @@ process {
                 // to 'cpsam'. Model choice goes through --pretrained-model.
                 params.containsKey('cellpose_pretrained_model') && params.cellpose_pretrained_model != null ?
                     "--pretrained-model ${params.cellpose_pretrained_model}" : null,
+                // Patch-local normalisation. sopa forwards --method-kwargs into
+                // cellpose_patch's **cellpose_eval_kwargs, which land on
+                // model.eval, so this is the only route to cellpose's own
+                // normalize dict. Passed only when non-zero: cellpose's default
+                // is tile_norm_blocksize=0 (whole-patch percentile), and
+                // sending the dict regardless would pin percentile even when
+                // tiling is off.
+                params.containsKey('cellpose_tile_norm_blocksize') && params.cellpose_tile_norm_blocksize ?
+                    "--method-kwargs '{\"normalize\": {\"tile_norm_blocksize\": ${params.cellpose_tile_norm_blocksize}, \"percentile\": [1.0, 99.0]}}'" : null,
+                // sopa's CLAHE, applied before cellpose. Left at sopa's
+                // defaults unless asked for.
+                params.containsKey('cellpose_clip_limit') && params.cellpose_clip_limit != null ?
+                    "--clip-limit ${params.cellpose_clip_limit}" : null,
+                params.containsKey('cellpose_clahe_kernel_size') && params.cellpose_clahe_kernel_size != null ?
+                    "--clahe-kernel-size ${params.cellpose_clahe_kernel_size}" : null,
+                params.containsKey('cellpose_gaussian_sigma') && params.cellpose_gaussian_sigma != null ?
+                    "--gaussian-sigma ${params.cellpose_gaussian_sigma}" : null,
                 // sopa warns that cellpose >=4 "can be slow without a GPU".
                 '--gpu'
             ].findAll { param -> param != null }.join(' ')

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -160,6 +160,39 @@ The following Mesmer parameters can be set:
 | cellpose_pretrained_model   | Model to segment with: a built-in name or a path to a custom model.    |
 | cellpose_models_dir         | Directory of pre-staged Cellpose weights; skips the download entirely. |
 
+Intensity preprocessing has its own parameter group, **Cellpose preprocessing
+options** — see [Preprocessing](#preprocessing-the-pipeline-matches-cellposes-own-contract)
+below.
+
+#### Most of these do not need adjusting on the SAM and DINO models
+
+Every model this pipeline offers — `cpsam_v2`, `cpsam`, `cpdino`, `cpdino-vitb` —
+is a Cellpose 4 transformer model, and the defaults below are already the values
+its authors use at test time. **The expected workflow is to change nothing and
+pick a model.** Tuning inherited from Cellpose 2/3 habits mostly does not apply.
+
+| Parameter                      | Needs tuning?                         | Why                                                                                                                                                                                                        |
+| ------------------------------ | ------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `cellpose_diameter`            | **No** — leave at 30                  | Cellpose-SAM trained on scales 0.25×–4× around a 30 px mean diameter, so it is scale-robust over ~7–120 px. 30 means `rescale = 1.0`, no resize.                                                           |
+| `cellpose_flow_threshold`      | **No** — 0.4 is the published default | The paper's test-time value. Raise only if you see fragmented or spurious masks.                                                                                                                           |
+| `cellpose_cellprob_threshold`  | **No** — 0.0 is the published default | The paper's test-time value. Lower to find more and larger masks, raise for fewer.                                                                                                                         |
+| `cellpose_gaussian_sigma`      | **No** — 0                            | sopa's addition; Cellpose applies no smoothing by default.                                                                                                                                                 |
+| `cellpose_clip_limit`          | **No** — 0                            | sopa's CLAHE, off. See the preprocessing section.                                                                                                                                                          |
+| `cellpose_clahe_kernel_size`   | **No** — inert while CLAHE is off     | —                                                                                                                                                                                                          |
+| `cellpose_tile_norm_blocksize` | **No** — 0 is Cellpose's own default  | Only worth touching for a specific normalisation experiment.                                                                                                                                               |
+| `cellpose_model_type`          | **Removed** — setting it is an error  | Cellpose 4 ignores `--model-type` entirely.                                                                                                                                                                |
+| `cellpose_pretrained_model`    | **Yes** — this is the real choice     | Which model runs. See [Choosing a model](#choosing-a-model).                                                                                                                                               |
+| `cellpose_min_area`            | **Maybe**                             | A pipeline-side size filter in px², not a model parameter. Set it for your cell type.                                                                                                                      |
+| `patch_width_pixel`            | **Only for memory/throughput**        | Cellpose tiles internally at 256 px regardless, so this controls task size and parallelism. With sopa's preprocessing disabled it has much less effect on results — see the reproducibility numbers below. |
+
+There is also **no automatic diameter estimation** in Cellpose 4: the paper states
+plainly that "there was no diameter estimation and resizing performed like in
+previous versions of Cellpose". If you know the QuPath Cellpose extension, note
+that its `.diameter(0.0)` "automatic computation" belongs to Cellpose 2/3, which
+shipped a `SizeModel`. That class no longer exists, and on Cellpose 4 a diameter
+of `0` silently means "do not rescale" rather than "estimate it" — so carrying the
+habit across produces a plausible but unintended run. Leave it at 30.
+
 `cellpose_model_type` has been **removed**. Cellpose 4 ignores `--model-type`
 (it logs `model_type argument is not used in v4.0.1+`), and sopa only reads it
 on the cellpose<4 code path, so the old `cyto3` default was silently discarded
@@ -198,6 +231,211 @@ The DINO models need Meta's `dinov3` package. The pinned container carries it,
 and only its architecture code is used, so Meta's gated backbone weights are not
 required. See `CITATIONS.md` for the licence terms, which apply if you
 redistribute the container or publish results using those models.
+
+#### Preprocessing: the pipeline matches Cellpose's own contract
+
+Cellpose normalises each image it is given by rescaling to the 1st and 99th
+percentiles, and does nothing else — its `sharpen_radius` and `smooth_radius`
+both default to `0`, and it contains no CLAHE code at all.
+
+That is not an inference from the code alone — it is the documented training
+recipe. The Cellpose-SAM paper states that "during training, all images were
+normalized such that 0 was set to the first percentile of the image intensity and
+1 was the 99th percentile", and that at test time "there was no diameter
+estimation and resizing performed like in previous versions of Cellpose".
+
+Sopa adds two preprocessing stages of its own on top of that, applied to every
+patch before Cellpose sees it: a `scipy` gaussian filter (`gaussian_sigma=1`)
+and CLAHE (`skimage.exposure.equalize_adapthist`, `clip_limit=0.2`). **This
+pipeline disables both**, so Cellpose receives exactly what its released weights
+were trained on:
+
+| Stage                                    | Whose    | Default here   |
+| ---------------------------------------- | -------- | -------------- |
+| `gaussian_filter(sigma)`                 | sopa     | **off** (`0`)  |
+| `equalize_adapthist(clip_limit, kernel)` | sopa     | **off** (`0`)  |
+| percentile (1, 99) rescale               | Cellpose | on (unchanged) |
+
+These four parameters form the **Cellpose preprocessing options** group:
+
+| Parameter Name               | Default | Description                                                                            |
+| ---------------------------- | ------- | -------------------------------------------------------------------------------------- |
+| cellpose_gaussian_sigma      | `0`     | sopa's gaussian smoothing sigma. `0` disables it; `null` restores sopa's `1`.          |
+| cellpose_clip_limit          | `0`     | sopa's CLAHE clip limit. `0` disables CLAHE; `null` restores sopa's `0.2`.             |
+| cellpose_clahe_kernel_size   | `null`  | CLAHE kernel in pixels. `null` means `patch.shape // 8`. No effect while CLAHE is off. |
+| cellpose_tile_norm_blocksize | `0`     | Cellpose tile-local normalisation block. `0` is Cellpose's whole-patch default.        |
+
+To restore sopa's behaviour, set `--cellpose_clip_limit 0.2` and
+`--cellpose_gaussian_sigma 1`.
+
+##### Why CLAHE is off
+
+Segmentation always runs on patches, and all of this normalisation is computed
+**from the patch**. A cell's input therefore depends on what else landed in its
+patch. Patch overlap does not help: it resolves cells straddling a boundary, not
+cells normalised differently.
+
+CLAHE was by far the largest contributor, for a specific reason: left at
+skimage's default, the CLAHE kernel is `patch.shape // 8`, so the
+contrast-enhancement length scale moves with `--patch_width_pixel`. At COMET's
+0.28 µm/px that is 52 µm at `patch_width_pixel=1500`, 105 µm at 3000 and 210 µm
+at 6000 — roughly 6 to 25 nuclear diameters for identical tissue, decided
+entirely by a patching knob.
+
+Cellpose-SAM's training augmentations are relevant to why this particular stage
+matters and the rest do not. Training jittered each channel's brightness (pixel
+mean, σ = 0.2) and rescaled its contrast (standard deviation), and degraded 50%
+of each batch with Poisson noise, gaussian blur, downsampling and anisotropic
+blur. So the model is explicitly robust to **global** intensity and contrast
+shifts, and to blurring — which is why sopa's gaussian is harmless, and why
+patch-to-patch differences in a single percentile rescale are tolerable. CLAHE is
+different in kind: it is a **spatially varying** local remapping, which is not in
+that augmentation set at any scale.
+
+Measured on a real 34-channel COMET image (DAPI, 32934×18076) by holding a
+1024² region fixed and varying only the patch layout, then recording how much
+the values Cellpose receives for those same physical pixels changed. Mean
+per-pixel spread, worst of two axes (patch size varied at fixed origin; patch
+origin shifted at fixed size). A gaussian-only control measured exactly 0.0000,
+which is what makes the rest meaningful:
+
+| Nuclei/mm² | DAPI+ | sopa preprocessing | Cellpose contract |
+| ---------- | ----- | ------------------ | ----------------- |
+| 2,250      | 10.1% | 0.1211             | **0.0265**        |
+| 2,932      | 14.6% | 0.0651             | **0.0052**        |
+| 4,647      | 24.2% | 0.0817             | **0.0075**        |
+| 12,006     | 66.2% | 0.0758             | **0.0553**        |
+
+Sparse tissue was the worst case, which matters because a whole-slide run covers
+every density.
+
+##### What that costs you in cells
+
+The above measures the network's input. The consequence is measurable in the
+output. Holding a 1024² region fixed and segmenting it as part of a 1500 px
+versus a 3000 px patch, then matching cells across the two layouts by IoU —
+i.e. **how many of your cells survive changing `patch_width_pixel` and nothing
+else**:
+
+| Model                | sopa: IoU ≥ 0.90 | Cellpose: IoU ≥ 0.90 | sopa mean IoU | Cellpose mean IoU |
+| -------------------- | ---------------- | -------------------- | ------------- | ----------------- |
+| `cpsam_v2` (default) | 103/267 (38.6%)  | **267/326 (81.9%)**  | 0.869         | 0.928             |
+| `cpsam`              | 155/359 (43.2%)  | **271/323 (83.9%)**  | 0.860         | 0.929             |
+| `cpdino`             | 74/201 (36.8%)   | **317/366 (86.6%)**  | 0.855         | 0.936             |
+
+Under sopa's preprocessing fewer than half of all cell boundaries survive a
+patch-size change, and it is worst for `cpsam_v2`, the default. All three models
+land at 82–87% once Cellpose's contract is used, with mean IoU rising from ~0.86
+to ~0.93. Three architectures, same direction, similar magnitude.
+
+##### What else changes
+
+Disabling sopa's preprocessing is **not** result-neutral. On dense patches:
+
+| Model      | Cell count       | Median cell area |
+| ---------- | ---------------- | ---------------- |
+| `cpsam_v2` | **+8% to +35%**  | −23% to −43%     |
+| `cpsam`    | **−3% to −10%**  | −25% to −37%     |
+| `cpdino`   | **+28% to +54%** | −25% to −42%     |
+
+The direction of the count change is model-dependent — CLAHE suppresses
+detections in the newer models and inflates them in `cpsam` — but **median cell
+area falls 23–43% for every model**. Since per-cell marker intensities are
+computed over these masks, downstream measurements shift accordingly, and results
+produced before and after this change should not be pooled in one analysis.
+
+Cells now come out smaller — measured equivalent diameters of ~24–27 px against
+the configured 30 — but `cellpose_diameter` almost certainly does **not** need
+changing for that. Cellpose-SAM was trained with images resized by a scale factor
+log-distributed between 0.25× and 4× relative to a 30 px mean cell diameter, so a
+1.2× scale discrepancy sits well inside the range it was trained to handle. The
+default of 30 gives `rescale = 1.0`, i.e. no resizing, which is what the paper's
+test-time protocol used.
+
+A secondary effect, worth knowing but **not** a reason on its own: CLAHE
+bypasses Cellpose's empty-patch guard. Cellpose zeroes a patch whose 1–99
+percentile range falls below `1e-3`, so an off-tissue patch reaches the network
+as zeros. `equalize_adapthist` expands an all-zero patch to the full range
+(mean 0.928, std 0.258), so that check never fires. On the image above, 13 of 84
+patches at `patch_width_pixel=3000` are entirely zero — unremarkable for exported
+ROIs with off-tissue padding.
+
+In practice this appears to be harmless: run on such a patch, `cpsam` returned
+**0 masks either way**, so the amplified field does not manufacture cells. Treat
+it as wasted work and a lost safety net rather than a correctness problem.
+
+##### Visual check on real tissue
+
+These defaults were run through the pipeline on a COMET brain-panel ROI
+(1683×2349 at 0.28 µm/px, DAPI plus four markers combined by `max`) with
+`cpsam_v2`, `cpdino` and cellSAM, and the resulting GeoJSONs were inspected in
+QuPath. All three loaded cleanly and looked closely comparable:
+
+| Method              | Cells | Median area        | Median equiv. diameter |
+| ------------------- | ----- | ------------------ | ---------------------- |
+| cellpose `cpsam_v2` | 1,742 | 864 px² (68 µm²)   | 33.2 px (9.3 µm)       |
+| cellpose `cpdino`   | 1,751 | 916 px² (72 µm²)   | 34.2 px (9.6 µm)       |
+| cellSAM             | 1,648 | 1,129 px² (89 µm²) | 37.9 px (10.6 µm)      |
+
+Three architecturally unrelated models landing within 6% on cell count is decent
+mutual corroboration. They differ on cell _size_: cellSAM draws noticeably larger,
+more generous boundaries around membrane signal — visible by eye in QuPath and
+matching the ~30% larger median area. `cpsam_v2` and `cpdino` are close to
+indistinguishable from one another.
+
+This is a plausibility check, not an accuracy measurement — there were no
+annotations to score against, so it establishes that the defaults produce sensible
+segmentation on real tissue, not that any one model is the most correct.
+
+> **All of this measures reproducibility, not accuracy.** It shows that the same
+> tissue yields the same cells regardless of how it happened to be patched. It
+> does **not** show the cells are more correct — a config could be perfectly
+> self-consistent and still segment badly, and nothing here was compared against
+> annotations. Sopa presumably added CLAHE because dim IF channels benefit from
+> it, and that trade is unevaluated. If your panel has weak markers, compare both
+> settings before trusting either.
+>
+> **Judging accuracy needs visual inspection**, against annotations or by eye in
+> QuPath, and no amount of normalisation measurement can substitute for it. The
+> defaults have been eyeballed on real tissue across three models (see the visual
+> check above) and produce sensible boundaries, but that is a plausibility check
+> rather than a scored comparison. Treat them as the reproducible starting point
+> and confirm the boundaries look right on your own panel. Both stages are one flag
+> each to restore, so the comparison is cheap to run.
+>
+> Measured on nuclear (DAPI) segmentation on one image. The whole-cell compartment
+> combines membrane markers, which are dimmer and sparser — precisely where CLAHE
+> would be earning its keep — and was not tested.
+>
+> Worth knowing for context: cellSAM also CLAHEs every block and works well —
+> but its released model was _trained_ with CLAHE applied, and it pins the kernel
+> at a fixed 128 px instead of deriving it from the block size. Cellpose's
+> weights were not trained that way. CLAHE is not inherently harmful; applying it
+> to a model that never saw it is the problem.
+
+##### Tile-local normalisation
+
+`--cellpose_tile_norm_blocksize` makes Cellpose's percentile statistics local to
+blocks within the patch rather than global to it. It defaults to `0`, Cellpose's
+own default, meaning whole-patch percentiles.
+
+If you enable it, keep the block much larger than a cell. At 0.28 µm/px with
+`--cellpose_diameter 30`, 512 px is 143 µm or ~17 nuclear diameters; 128 px is
+36 µm or ~4, small enough that a block in sparse tissue may contain no nuclei at
+all. At 128 the minimum per-block 1–99 range fell to 5.0 against 1670 for the
+whole patch, and since Cellpose only guards a flat block below `1e-3` it rescued
+none of them — noise was stretched to full range and patch dependence got 3–24×
+_worse_. Note also that enabling it while CLAHE is on regresses: the two stages
+stack rather than cancel.
+
+Neither option removes patch-locality entirely, because the block grid is still
+laid out relative to the patch. Cellpose's `lowhigh` would — it applies fixed
+absolute bounds with no patch statistics at all — but that is probably not an
+improvement here. Cellpose-SAM was trained by normalising **each image** to its
+own 1st/99th percentiles and then taking 256×256 crops, so per-patch percentile
+normalisation is the closer analogue of the training setup; fixed cohort-wide
+bounds would move further from it, not closer. Leave `lowhigh` alone unless you
+have a specific reason.
 
 #### GPU
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -51,6 +51,40 @@ params {
     cellpose_model_type          = null
     cellpose_pretrained_model    = 'cpsam_v2'
     cellpose_models_dir          = null
+    // Match cellpose's own preprocessing contract: percentile (1, 99) over the
+    // patch and nothing else. sopa layers two extra stages on top -- a gaussian
+    // filter and CLAHE -- neither of which exists anywhere in cellpose, whose
+    // released weights were trained on percentile-normalised input. Both are
+    // disabled below.
+    //
+    // 0 is cellpose's default (whole-patch percentile). A non-zero value makes
+    // the percentile statistics local to blocks within the patch; if you enable
+    // it, keep the block far larger than a cell -- at COMET's 0.28 um/px,
+    // 512 px is 143 um or ~17 nuclear diameters, while 128 px is 36 um or ~4,
+    // small enough that a block in sparse tissue may hold no nuclei at all and
+    // have its noise stretched to the full range.
+    cellpose_tile_norm_blocksize = 0
+    // CLAHE off. sopa runs skimage.exposure.equalize_adapthist on every patch
+    // before cellpose sees it -- sopa's own addition, absent from cellpose,
+    // whose released weights were trained on percentile-normalised input.
+    //
+    // It is also the largest single source of patch dependence here, because
+    // skimage derives the kernel from the patch (patch.shape // 8): 52 um at
+    // patch_width_pixel=1500, 105 um at 3000, 210 um at 6000. Pinning the
+    // kernel only helps on the size axis, and tile_norm_blocksize above does
+    // nothing while CLAHE remains on -- the two stack rather than cancel.
+    //
+    // Set to null to restore sopa's default of 0.2. clahe_kernel_size has no
+    // effect while CLAHE is disabled.
+    cellpose_clip_limit          = 0
+    cellpose_clahe_kernel_size   = null
+    // Gaussian smoothing off, also sopa's addition rather than cellpose's.
+    // Unlike CLAHE this is not a source of patch dependence -- a sigma=1
+    // convolution is local, and a gaussian-only control measured exactly zero
+    // spread across patch layouts -- so this is purely about matching
+    // cellpose's contract, not about stability. null restores sopa's default
+    // of 1.
+    cellpose_gaussian_sigma      = 0
 
     // mesmer options
     mesmer_segmentation_level    = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -139,7 +139,7 @@
                 "cellpose_pretrained_model": {
                     "type": "string",
                     "description": "Cellpose model to segment with: cpsam_v2 (default), cpsam, cpdino, cpdino-vitb, or a path to a custom model.",
-                    "help_text": "Selects the Cellpose model. Accepts either a built-in model name or a filesystem path to your own trained model.\n\nBuilt-in models (cellpose 4.2.1.1):\n\n- `cpsam_v2` — default; the current Cellpose-SAM model.\n- `cpsam` — the previous Cellpose-SAM model. Use this to reproduce results from before this pipeline moved to cellpose 4.2.\n- `cpdino` — DINOv3-backbone model added in cellpose 4.2 (ViT-L, ~303M parameters).\n- `cpdino-vitb` — smaller ViT-B DINOv3 variant.\n\nThe DINO models need Meta's `dinov3` package, which the pinned container carries. Only its architecture code is used — Cellpose builds the backbone with `pretrained=False` and loads its own weights — so Meta's gated backbone weights are not required. Note the DINOv3 licence terms in CITATIONS.md if you redistribute the container or publish results using these models.\n\nA path is passed through untouched, so a custom model is loaded directly and no download occurs. Built-in names are fetched once per run by CELLPOSEMODEL, or read from --cellpose_models_dir if you have a pre-staged copy.",
+                    "help_text": "Selects the Cellpose model. Accepts either a built-in model name or a filesystem path to your own trained model.\n\nBuilt-in models (cellpose 4.2.1.1):\n\n- `cpsam_v2` \u2014 default; the current Cellpose-SAM model.\n- `cpsam` \u2014 the previous Cellpose-SAM model. Use this to reproduce results from before this pipeline moved to cellpose 4.2.\n- `cpdino` \u2014 DINOv3-backbone model added in cellpose 4.2 (ViT-L, ~303M parameters).\n- `cpdino-vitb` \u2014 smaller ViT-B DINOv3 variant.\n\nThe DINO models need Meta's `dinov3` package, which the pinned container carries. Only its architecture code is used \u2014 Cellpose builds the backbone with `pretrained=False` and loads its own weights \u2014 so Meta's gated backbone weights are not required. Note the DINOv3 licence terms in CITATIONS.md if you redistribute the container or publish results using these models.\n\nA path is passed through untouched, so a custom model is loaded directly and no download occurs. Built-in names are fetched once per run by CELLPOSEMODEL, or read from --cellpose_models_dir if you have a pre-staged copy.",
                     "fa_icon": "fas fa-file-upload"
                 },
                 "cellpose_models_dir": {
@@ -148,6 +148,43 @@
                     "description": "Directory holding pre-staged Cellpose model weights. If set, the pipeline uses it instead of downloading them.",
                     "help_text": "Point this at a shared copy of the Cellpose model cache (the directory holding e.g. `cpsam`) to skip the download entirely. Recommended on clusters where compute nodes have no outbound network access.",
                     "fa_icon": "fas fa-folder-open"
+                }
+            }
+        },
+        "cellpose_preprocessing_options": {
+            "title": "Cellpose preprocessing options",
+            "type": "object",
+            "fa_icon": "fas fa-sliders-h",
+            "description": "Intensity preprocessing applied before Cellpose segmentation.",
+            "help_text": "The defaults here make the pipeline match Cellpose's own preprocessing contract: rescale to the 1st and 99th percentiles and nothing else.\n\nsopa adds a gaussian filter and CLAHE of its own, neither of which exists in Cellpose, and both are disabled. All of this normalisation is computed per patch, so leaving sopa's stages on makes a cell's segmentation depend on what else landed in its patch and on the value of `--patch_width_pixel`. See the preprocessing section of `docs/usage.md` for the measurements behind these defaults and for how to restore sopa's behaviour.",
+            "properties": {
+                "cellpose_tile_norm_blocksize": {
+                    "type": "integer",
+                    "minimum": 0,
+                    "description": "Block size in pixels for Cellpose's tile-local intensity normalisation. 0 uses Cellpose's whole-patch default.",
+                    "help_text": "Segmentation always runs on patches, and normalisation is computed from the patch, so without this a cell's segmentation depends on what else landed in its patch and changing `--patch_width_pixel` changes results. Patch overlap does not help: it resolves cells straddling a boundary, not differing normalisation.\n\nThis is forwarded as `--method-kwargs '{\"normalize\": {\"tile_norm_blocksize\": N, \"percentile\": [1.0, 99.0]}}'`, which sopa passes into `model.eval`, making the percentile statistics local to each block rather than global to the patch.\n\nChoose a block that comfortably contains many nuclei. At COMET's 0.28 um/px with `--cellpose_diameter 30` (8.4 um cells), 512 px is 143 um, about 17 nuclear diameters. Small blocks are actively harmful: a 128 px (36 um) block spans roughly 4 cell diameters, so in sparse tissue it can contain no nuclei at all and its noise is stretched to the full range. Cellpose only guards a flat block when its 1-99 percentile range falls below 1e-3, which such blocks exceed.\n\nNote this does not normalise across the whole image -- nothing in the patch-parallel design ever sees it.",
+                    "fa_icon": "fas fa-th"
+                },
+                "cellpose_clip_limit": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "sopa's CLAHE clip limit, applied before Cellpose. Defaults to 0 in this pipeline, disabling CLAHE; null restores sopa's default of 0.2.",
+                    "help_text": "sopa runs `skimage.exposure.equalize_adapthist` on each patch before Cellpose sees it. This is sopa's addition, not part of Cellpose -- Cellpose contains no CLAHE code, and its released weights were trained on percentile-normalised input, so this preprocessing is off that contract.\n\nSetting 0 disables CLAHE. Worth testing: CLAHE is the largest single source of patch-dependence in this stack, and on an all-zero patch it expands the image to the full range, which defeats Cellpose's own empty-patch guard.",
+                    "fa_icon": "fas fa-adjust"
+                },
+                "cellpose_clahe_kernel_size": {
+                    "type": "integer",
+                    "minimum": 1,
+                    "description": "Kernel size in pixels for sopa's CLAHE. Unset uses skimage's default of patch.shape // 8, which scales with patch_width_pixel.",
+                    "help_text": "Left unset, skimage derives the kernel from the patch: 1/8 of its height and width. The contrast-enhancement length scale therefore moves with `--patch_width_pixel` -- 187 px (52 um) at 1500, 375 px (105 um) at 3000, 750 px (210 um) at 6000 -- so the same tissue is enhanced differently purely because of a patching knob.\n\nPinning an absolute value removes that coupling. cellSAM, which also CLAHEs each block, fixes its kernel at 128 px rather than deriving it from the block size.\n\nHas no effect while `--cellpose_clip_limit` is 0.",
+                    "fa_icon": "fas fa-ruler-combined"
+                },
+                "cellpose_gaussian_sigma": {
+                    "type": "number",
+                    "minimum": 0,
+                    "description": "Sigma for sopa's gaussian smoothing, applied before Cellpose. Defaults to 0 in this pipeline, disabling it; null restores sopa's default of 1.",
+                    "help_text": "Like CLAHE, this is sopa's addition rather than Cellpose's: Cellpose's own smoothing and sharpening parameters (`smooth_radius`, `sharpen_radius`) both default to 0, and it applies neither unless asked.\n\nUnlike CLAHE this is not a source of patch dependence, since a small-sigma convolution is local and only edge reflection differs between patch layouts. Disabling it is therefore about matching Cellpose's preprocessing contract, not about stability. Raise it if your data is noisy enough to need denoising before segmentation.",
+                    "fa_icon": "fas fa-water"
                 }
             }
         },
@@ -704,6 +741,9 @@
         },
         {
             "$ref": "#/$defs/cellpose_options"
+        },
+        {
+            "$ref": "#/$defs/cellpose_preprocessing_options"
         },
         {
             "$ref": "#/$defs/mesmer_options"


### PR DESCRIPTION
Sopa applies two preprocessing stages Cellpose doesn't have — a gaussian blur and
CLAHE — to every patch before Cellpose sees it. Both are now off, so Cellpose gets
the percentile-(1,99) input its released weights were trained on.

## Why

Both stages are computed **per patch**, and CLAHE's kernel is `patch.shape // 8` — so
the contrast-enhancement scale tracks `patch_width_pixel`. At COMET's 0.28 µm/px
that's 52 µm at 1500 px, 105 µm at 3000 and 210 µm at 6000 for identical tissue.

Segmenting the same region as part of a 1500 px vs a 3000 px patch and matching cells
by IoU — how many boundaries survive changing only the patch size:

| Model | before | after |
| --- | --- | --- |
| `cpsam_v2` (default) | 38.6% | **81.9%** |
| `cpsam` | 43.2% | **83.9%** |
| `cpdino` | 36.8% | **86.6%** |

Cells reproduced at IoU ≥ 0.90; mean IoU 0.86 → 0.93. Fewer than half used to
survive, worst for the default model. Three architectures, same direction.

## :warning: This changes results

**Median cell area falls 23–43% for every model.** Counts move too, direction
depending on the model: +8–35% (`cpsam_v2`), −3–10% (`cpsam`), +28–54% (`cpdino`) —
CLAHE was suppressing detections in the newer models and inflating them in `cpsam`.
Per-cell intensities are computed over these masks, so **don't pool results from
before and after this change.**

`cellpose_diameter` needs no adjustment — Cellpose-SAM trained across 0.25×–4× scale,
so the now-smaller cells sit well inside its range.

## Params

| Param | Default | |
| --- | --- | --- |
| `cellpose_gaussian_sigma` | `0` | sopa's gaussian, off |
| `cellpose_clip_limit` | `0` | sopa's CLAHE, off |
| `cellpose_clahe_kernel_size` | `null` | inert while CLAHE is off |
| `cellpose_tile_norm_blocksize` | `0` | Cellpose's own default |

In a dedicated **Cellpose preprocessing options** schema group so they don't crowd
the Cellpose section in Seqera. Revert with
`--cellpose_clip_limit 0.2 --cellpose_gaussian_sigma 1`.

Config only — no sopa or cellpose code changes.

## Verified

- End to end on the `test` profile: 30 tasks, no failures, exercising the multi-patch
  path (`patch_width_pixel=250` → nine patches per compartment).
- Flags confirmed reaching `model.eval` in the pinned sopa 2.2.6 — including that
  `--clip-limit 0` isn't swallowed by Groovy truthiness.
- Run on a COMET brain-panel ROI with `cpsam_v2`, `cpdino` and cellSAM, inspected in
  QuPath: all three sensible and closely comparable (1,742 / 1,751 / 1,648 cells),
  cellSAM drawing larger boundaries around membrane signal.

## Limits

These numbers measure **reproducibility, not accuracy** — no annotations were scored,
and the normalisation measurements are DAPI-only, so the whole-cell compartment is
unmeasured. Sopa presumably added CLAHE because dim IF channels benefit; that trade
is unevaluated.

cellSAM also CLAHEs each block and works well — but it was *trained* with CLAHE and
pins its kernel at a fixed 128 px. Cellpose's weights were not. Applying it to a
model that never saw it is the problem, not CLAHE itself.

Full reasoning in [docs/usage.md](docs/usage.md).

**Follow-up:** nf-test snapshots for the cellpose path need regenerating. CI doesn't
run nf-test (dropped in 1761b7c), so this is hygiene rather than a merge gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
