### PR TITLE
feat: add kronos_exclude_markers, and fix split-series channel reads

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -27,6 +27,25 @@ jobs:
       - name: Run pre-commit
         run: pre-commit run --all-files
 
+  pytest:
+    # Unit tests for the bin/ scripts. Deliberately dependency-light: these cover
+    # the pure logic (channel naming, exclusion, the marker report), so they need
+    # no torch, no GPU and no gated model weights, and run in seconds.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5
+        with:
+          python-version: "3.12"
+
+      - name: Install test dependencies
+        run: pip install pytest numpy tifffile
+
+      - name: Run pytest
+        run: pytest tests/python -q
+
   nf-core:
     runs-on: ubuntu-latest
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -189,6 +189,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`kronos_exclude_markers`, which withholds channels from KRONOS2 so they
+  contribute nothing to the embedding.** A COMET panel's `Autofluorescence`
+  channel is not a marker and is not in the 288-marker vocabulary, so the run
+  failed with only one escape -- `kronos_allow_novel_defaults` -- which still
+  _feeds_ the channel to the model, normalised with default statistics, the
+  opposite of what is wanted. This is scoped to the embedding step and deletes
+  nothing: the reader opens only the kept channel indices, so a withheld channel
+  is never read, while it stays in the image, remains available to every other
+  process, and keeps the intensity measurements CELLMEASUREMENT wrote for it.
+  (Contrast `remove_markers`, which does strip channels out of the
+  background-subtracted image.) Names are comma separated and case sensitive,
+  matched against the image's own channel names before any
+  `kronos_marker_mapping`; a name matching nothing fails the run and lists what
+  is present, and the nuclear channel cannot be withheld because it is the
+  model's `preferred_dapi`. The marker report shows withheld channels in place.
+  **KRONOS2 attends across the channel set, so this changes every channel's
+  embedding** -- hold the list constant across a cohort.
+
 - **The `cpdino` and `cpdino-vitb` models are usable.** Cellpose needs Meta's
   `dinov3` for these, imports it in a bare `try`/`except` that only warns, and
   then dies with `NameError: name 'dinov3_vitl16' is not defined` when the model
@@ -242,6 +260,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **:warning: KRONOS2 embedded one channel's pixels under every marker's name on
+  OME-TIFFs that store each channel as its own 2D series.** `ChannelReader` sized
+  itself from `series[0]` alone, so an 8-series image read as 1 channel while the
+  patch buffer was still sized from the 8-name marker list -- and numpy broadcast
+  that single channel across all eight. The run completed, reported the right
+  channel count, and produced 768-d vectors computed from eight copies of DAPI.
+  The layout is now detected up front and each channel read from its own series,
+  the reader refuses to return fewer channels than were asked of it, and the run
+  fails if the channel-name count and the image's channel count disagree.
+  **Embeddings produced from such images by earlier versions are invalid and must
+  be regenerated.** The COMET `_fixed` images written by the inForm unmixing
+  export are affected.
+- A channel whose OME `Channel` element carried neither `Name` nor `ID` was
+  dropped from the marker list but not from the image the reader opened, sliding
+  every later marker onto the wrong channel. Names are now built positionally,
+  with one entry per channel always.
 - Stub runs of the Cellpose path failed with `For input string: ""`. The
   `SOPA_PATCHIFYIMAGE` stub wrote an empty patch-count file that the caller parses
   with `.toInteger()`.

--- a/bin/kronos2_common.py
+++ b/bin/kronos2_common.py
@@ -99,17 +99,43 @@ def scaling_factor(dtype):
 # ----------------------------------------------------------------------------
 
 
+def channel_layout(tif):
+    """How a TIFF stores its channels: ``("stacked" | "split", n_channels)``.
+
+    Two layouts occur in practice. The usual one keeps every channel in a single
+    ``CYX`` series. The other gives each channel its own 2D series, which some
+    OME writers produce -- notably the inForm unmixing export behind the COMET
+    ``_fixed`` images. A reader that only consults ``series[0]`` sees the second
+    as a one-channel image, and since the patch buffer is sized from the *marker*
+    list, numpy then broadcasts that single channel's pixels under every marker's
+    name: an embedding of one channel wearing eight labels, with no error. Both
+    the name list and the pixel reader derive the channel count from here so they
+    cannot disagree about what a channel is.
+    """
+    series = list(getattr(tif, "series", None) or [])
+    if (
+        len(series) > 1
+        and all(len(s.shape) == 2 for s in series)
+        and len({tuple(s.shape) for s in series}) == 1
+    ):
+        return "split", len(series)
+    if series:
+        shape = tuple(series[0].shape)
+        return "stacked", (shape[0] if len(shape) >= 3 else 1)
+    return "stacked", (len(tif.pages) if len(tif.pages) > 1 else 1)
+
+
 def get_channel_names(tiff_path):
     """Channel names from OME-XML, then ImageJ labels, then numbered fallback.
 
-    Reads metadata only -- no pixel decode.
+    Reads metadata only -- no pixel decode. The result always holds exactly one
+    entry per image channel: a channel the metadata leaves unnamed gets a
+    synthesised name rather than being dropped. Dropping shortened the list while
+    leaving the image unchanged, sliding every later name onto the wrong channel
+    index -- and those indices are what ``ChannelReader`` reads pixels by.
     """
     with tifffile.TiffFile(tiff_path) as tif:
-        if tif.series:
-            shape = tif.series[0].shape
-            n_channels = shape[0] if len(shape) >= 3 else 1
-        else:
-            n_channels = len(tif.pages) if len(tif.pages) > 1 else 1
+        _, n_channels = channel_layout(tif)
 
         names = []
         if tif.is_ome:
@@ -129,10 +155,9 @@ def get_channel_names(tiff_path):
             if "Labels" in tif.imagej_metadata:
                 names = list(tif.imagej_metadata["Labels"])
 
-        if not names:
-            names = [f"Channel_{i}" for i in range(n_channels)]
-
-    return [n for n in names if n is not None]
+    names = [name or f"Channel_{i}" for i, name in enumerate(names[:n_channels])]
+    names += [f"Channel_{i}" for i in range(len(names), n_channels)]
+    return names
 
 
 def load_marker_mapping(arg):
@@ -169,6 +194,68 @@ def apply_marker_mapping(names, mapping):
         else:
             resolved.append(name)
     return resolved, applied
+
+
+def select_channels(channel_names, exclude=(), protect=None):
+    """Channel indices to show the model, skipping ``exclude``.
+
+    Returns ``(keep_indices, kept_names, excluded_names)``. Matching is exact and
+    case sensitive against the image's own channel names, *before* any
+    ``--marker-mapping`` rename -- you cannot map a channel you intend to skip,
+    and keeping both keyed on the same strings means the channel list is read
+    once.
+
+    Scoped to this step alone. A skipped channel is simply never read, so it
+    contributes nothing to the embedding; it stays in the image, stays available
+    to every other process, and keeps whatever intensity measurements
+    CELLMEASUREMENT already wrote for it. Nothing is deleted from anything.
+
+    This is for channels that are not markers: autofluorescence, blanks, empty
+    cycles. Such a channel has no vocabulary entry and no mapping can give it
+    one, and ``--allow-novel-defaults`` is the wrong instrument because it still
+    *feeds* the channel to the model, normalised with default statistics.
+
+    Raises ValueError rather than skipping anything silently: an unmatched name
+    means a typo produced a full-panel embedding that looks perfectly fine.
+    """
+    wanted, seen = [], set()
+    for name in exclude or ():
+        name = name.strip()
+        if name and name not in seen:
+            seen.add(name)
+            wanted.append(name)
+
+    missing = [name for name in wanted if name not in channel_names]
+    if missing:
+        raise ValueError(
+            f"cannot exclude {missing}: no such channel. This image has: "
+            f"{list(channel_names)} (matching is case sensitive, and uses the "
+            "image's own channel names, not mapped ones)"
+        )
+
+    if protect and protect in seen:
+        raise ValueError(
+            f"cannot exclude {protect!r}: it is the nuclear marker, which "
+            "KRONOS2 takes as preferred_dapi. That is the model's only alias "
+            "mechanism and the DAPI statistics anchor the normalisation of "
+            "every other channel"
+        )
+
+    keep_indices, kept_names, excluded_names = [], [], []
+    for index, name in enumerate(channel_names):
+        if name in seen:
+            excluded_names.append(name)
+        else:
+            keep_indices.append(index)
+            kept_names.append(name)
+
+    if not keep_indices:
+        raise ValueError(
+            f"excluding {len(excluded_names)} channel(s) would leave nothing to "
+            "embed"
+        )
+
+    return keep_indices, kept_names, excluded_names
 
 
 # ----------------------------------------------------------------------------
@@ -252,51 +339,98 @@ class ChannelReader:
     ~72 GB if materialised, which does not fit the process_multi allocation.
     Falls back to an eager read for layouts zarr cannot open, and says which
     path it took.
+
+    Handles both layouts ``channel_layout`` distinguishes. In the split layout
+    each channel is its own 2D series, so there is one zarr view per channel
+    instead of one indexed by a channel axis; ``read_window`` returns the same
+    ``(len(channels), h, w)`` block either way and callers need not care.
+
+    ``channels`` is a list of channel *indices* -- a subset is normal (see
+    ``select_channels``) and only those channels are ever read.
     """
 
     def __init__(self, tiff_path, channels):
         self.path = str(tiff_path)
         self.channels = list(channels)
         self._store = None
+        self._stores = []
         self._zarr = None
+        self._zarrs = None
         self._eager = None
 
         with tifffile.TiffFile(self.path) as tif:
+            self.layout, self.n_channels = channel_layout(tif)
             series = tif.series[0]
             self.shape = tuple(series.shape)
             self.dtype = np.dtype(series.dtype)
-
-        if len(self.shape) == 2:
-            self.n_channels, self.height, self.width = 1, self.shape[0], self.shape[1]
-        else:
-            self.n_channels, self.height, self.width = (
-                self.shape[0],
-                self.shape[-2],
-                self.shape[-1],
-            )
+            self.height, self.width = self.shape[-2], self.shape[-1]
 
         try:
             import zarr
 
-            self._store = tifffile.imread(self.path, aszarr=True)
-            self._zarr = zarr.open(self._store, mode="r")
-            # A pyramidal OME-TIFF opens as a group; level 0 is full resolution.
-            if hasattr(self._zarr, "keys") and not hasattr(self._zarr, "shape"):
-                self._zarr = self._zarr[sorted(self._zarr.keys())[0]]
+            if self.layout == "split":
+                # One store per channel, each owning its own file handle exactly
+                # as the stacked path's imread() does -- borrowing them from a
+                # TiffFile that closes here would leave their lifetime unclear.
+                # Only the kept channels are opened.
+                self._zarrs = []
+                for index in self.channels:
+                    store = tifffile.imread(self.path, aszarr=True, series=index)
+                    self._stores.append(store)
+                    self._zarrs.append(self._level0(zarr.open(store, mode="r")))
+            else:
+                self._store = tifffile.imread(self.path, aszarr=True)
+                self._zarr = self._level0(zarr.open(self._store, mode="r"))
             self.mode = "lazy"
         except Exception as exc:  # noqa: BLE001 - fall back, never fail here
             log(f"  lazy zarr view unavailable ({exc}); falling back to full read")
-            arr = tifffile.imread(self.path)
-            if arr.ndim == 2:
-                arr = arr[np.newaxis]
-            arr = arr.reshape(-1, arr.shape[-2], arr.shape[-1])
-            self._eager = arr[self.channels]
+            self.close()
+            self._zarr, self._zarrs = None, None
+            if self.layout == "split":
+                # imread() would hand back series[0] alone, so name the series.
+                with tifffile.TiffFile(self.path) as tif:
+                    self._eager = np.stack(
+                        [tif.series[index].asarray() for index in self.channels]
+                    )
+            else:
+                arr = tifffile.imread(self.path)
+                if arr.ndim == 2:
+                    arr = arr[np.newaxis]
+                arr = arr.reshape(-1, arr.shape[-2], arr.shape[-1])
+                self._eager = arr[self.channels]
             self.mode = "eager"
 
+    @staticmethod
+    def _level0(view):
+        """A pyramidal OME-TIFF opens as a group; level 0 is full resolution."""
+        if hasattr(view, "keys") and not hasattr(view, "shape"):
+            return view[sorted(view.keys())[0]]
+        return view
+
     def read_window(self, y0, y1, x0, x1):
-        """``(len(channels), y1-y0, x1-x0)`` window, clipped to the image."""
+        """``(len(channels), y1-y0, x1-x0)`` window, clipped to the image.
+
+        The channel count is checked rather than trusted: the patch buffer is
+        sized from the marker list, so a window with too few channels would be
+        broadcast into it by numpy and every marker would silently receive the
+        same pixels. Failing here costs one shape comparison per patch.
+        """
+        window = self._read_window(y0, y1, x0, x1)
+        if window.shape[0] != len(self.channels):
+            raise ValueError(
+                f"read {window.shape[0]} channel(s) for {len(self.channels)} "
+                f"requested from a {self.layout}-layout image; refusing to "
+                "broadcast one channel across several markers"
+            )
+        return window
+
+    def _read_window(self, y0, y1, x0, x1):
         if self._eager is not None:
             return self._eager[:, y0:y1, x0:x1]
+        if self._zarrs is not None:
+            return np.stack(
+                [np.asarray(arr[y0:y1, x0:x1]) for arr in self._zarrs], axis=0
+            )
         arr = self._zarr
         if arr.ndim == 2:
             return np.asarray(arr[y0:y1, x0:x1])[np.newaxis]
@@ -305,11 +439,14 @@ class ChannelReader:
         )
 
     def close(self):
-        if self._store is not None:
+        for store in [self._store, *self._stores]:
+            if store is None:
+                continue
             try:
-                self._store.close()
+                store.close()
             except Exception:
                 pass
+        self._store, self._stores = None, []
 
 
 # ----------------------------------------------------------------------------
@@ -443,20 +580,56 @@ def write_geojson_with_embeddings(
     return len(features)
 
 
-def write_marker_report(path, tiff, channel_names, resolved, applied, extra_lines=()):
-    """Human-readable record of how each channel was presented to the model."""
+def write_marker_report(
+    path, tiff, channel_names, resolved, applied, extra_lines=(), keep_indices=None
+):
+    """Human-readable record of how each channel was presented to the model.
+
+    ``channel_names`` is the image's full channel list, so the header count stays
+    honest about the file; ``resolved`` covers only the channels actually
+    embedded, and ``keep_indices`` says which ones those were. ``None`` means
+    everything was kept, which reproduces the report as it was before exclusion
+    existed.
+
+    Withheld channels appear twice on purpose: in place, so "what happened to
+    channel 8" needs no counting, and as a trailing block that stays greppable on
+    a forty-marker panel. Both say "not shown to KRONOS2" rather than "removed",
+    because that is the truth -- the channel is still in the image.
+    """
+    if keep_indices is None:
+        keep_indices = list(range(len(channel_names)))
+    by_index = dict(zip(keep_indices, resolved))
+    excluded = [name for i, name in enumerate(channel_names) if i not in by_index]
+
     with open(path, "w") as fh:
         fh.write("KRONOS2 Marker Report\n")
         fh.write("=" * 60 + "\n\n")
         fh.write(f"Image: {tiff}\n")
-        fh.write(f"Channels: {len(channel_names)}\n\n")
+        if excluded:
+            fh.write(
+                f"Channels: {len(channel_names)} "
+                f"({len(by_index)} embedded, {len(excluded)} not shown)\n\n"
+            )
+        else:
+            fh.write(f"Channels: {len(channel_names)}\n\n")
         fh.write("Channel -> name given to KRONOS2\n")
-        for raw, res in zip(channel_names, resolved):
+        for index, raw in enumerate(channel_names):
+            if index not in by_index:
+                fh.write(f"  {raw} -> (not shown to KRONOS2)\n")
+                continue
+            res = by_index[index]
             note = "  (mapped)" if raw != res else ""
             fh.write(f"  {raw} -> {res}{note}\n")
         if applied:
             fh.write("\nMappings applied via --marker-mapping:\n")
             for src, dst in applied:
                 fh.write(f"  {src} -> {dst}\n")
+        if excluded:
+            fh.write(
+                "\nWithheld from KRONOS2 via --exclude-marker "
+                "(still present in the image):\n"
+            )
+            for name in excluded:
+                fh.write(f"  {name}\n")
         for line in extra_lines:
             fh.write(f"\n{line}\n")

--- a/bin/kronos2_embeddings.py
+++ b/bin/kronos2_embeddings.py
@@ -23,7 +23,7 @@ Usage:
         --output-geojson sample.geojson.gz \
         [--patch-size 64] [--batch-size 16] \
         [--marker-mapping map.json] [--nuclear-marker DAPI-01] \
-        [--no-isolate-cell]
+        [--exclude-marker Autofluorescence] [--no-isolate-cell]
 """
 
 import argparse
@@ -45,6 +45,7 @@ from kronos2_common import (
     numpy_collate,
     read_cells,
     scaling_factor,
+    select_channels,
     write_geojson_with_embeddings,
     write_marker_report,
 )
@@ -180,6 +181,21 @@ def main():
     )
     parser.add_argument("--marker-mapping", default=None)
     parser.add_argument(
+        "--exclude-marker",
+        dest="exclude_markers",
+        action="append",
+        default=None,
+        metavar="NAME",
+        help="Do not show this channel to KRONOS2, so it contributes nothing to "
+        "the embedding; repeatable. Affects this step only -- the channel stays "
+        "in the image and keeps any measurements already written for it. "
+        "Matched exactly and case sensitively against the image's own channel "
+        "names, before --marker-mapping. For channels that are not markers -- "
+        "autofluorescence, blanks, empty cycles -- where no mapping can help. "
+        "Unlike --allow-novel-defaults, which still feeds the channel to the "
+        "model, this one never reaches it. A name matching no channel fails.",
+    )
+    parser.add_argument(
         "--nuclear-marker",
         default=None,
         help="Channel to treat as the nuclear stain; the model's only alias "
@@ -205,10 +221,31 @@ def main():
     # --- channels + marker names ------------------------------------------
     channel_names = get_channel_names(args.tiff)
     log(f"Found {len(channel_names)} channels")
+
+    try:
+        keep_indices, kept_names, excluded = select_channels(
+            channel_names, args.exclude_markers or [], protect=args.nuclear_marker
+        )
+    except ValueError as exc:
+        log(f"ERROR: {exc}")
+        sys.exit(1)
+    if excluded:
+        log(
+            f"  not showing KRONOS2 {len(excluded)} channel(s): {excluded} "
+            "(they stay in the image; this affects the embedding only)"
+        )
+    log(
+        f"  embedding {len(kept_names)} of {len(channel_names)} channels: "
+        f"{kept_names}"
+    )
+    if len(kept_names) == 1:
+        log("WARNING: only 1 channel left to embed")
+
     mapping = load_marker_mapping(args.marker_mapping)
-    markers, applied = apply_marker_mapping(channel_names, mapping)
+    markers, applied = apply_marker_mapping(kept_names, mapping)
     if applied:
         log(f"  applied {len(applied)} marker mapping(s)")
+    log(f"  markers given to KRONOS2: {markers}")
 
     # --- cells -------------------------------------------------------------
     log(f"Reading cells from {args.geojson}")
@@ -216,11 +253,19 @@ def main():
     log(f"  {len(features)} cells")
 
     # --- image -------------------------------------------------------------
-    reader = ChannelReader(args.tiff, list(range(len(channel_names))))
+    reader = ChannelReader(args.tiff, keep_indices)
+    if len(channel_names) != reader.n_channels:
+        log(
+            f"ERROR: {len(channel_names)} channel names for a "
+            f"{reader.n_channels}-channel image; names and channel indices "
+            "cannot be aligned, so markers would describe the wrong pixels"
+        )
+        sys.exit(1)
     divisor = args.max_value if args.max_value else scaling_factor(reader.dtype)
     log(
-        f"  image {reader.n_channels}x{reader.height}x{reader.width} "
-        f"dtype={reader.dtype} divisor={divisor} access={reader.mode}"
+        f"  image {len(reader.channels)}/{reader.n_channels} channels "
+        f"{reader.height}x{reader.width} dtype={reader.dtype} "
+        f"divisor={divisor} layout={reader.layout} access={reader.mode}"
     )
 
     # --- model -------------------------------------------------------------
@@ -234,21 +279,34 @@ def main():
             f"vocabulary and will use DEFAULT normalisation stats: {unseen}"
         )
         report_extra.append("Novel markers (default stats used):\n  " + "\n  ".join(unseen))
+
+    # Written before the gate below can exit: a failing run is exactly when the
+    # report is most useful, since it is where the channel names to map or
+    # exclude are listed.
+    if args.marker_report:
+        write_marker_report(
+            args.marker_report,
+            args.tiff,
+            channel_names,
+            markers,
+            applied,
+            report_extra,
+            keep_indices=keep_indices,
+        )
+
+    if unseen:
         if args.allow_novel_defaults:
             log(f"WARNING: {msg}")
         else:
             log(f"ERROR: {msg}")
             log(
                 "  Most novel markers are naming variants, not new biology -- "
-                "map them onto vocabulary names with --marker-mapping. Re-run "
-                "with --allow-novel-defaults to accept default stats instead."
+                "map them onto vocabulary names with --marker-mapping. Channels "
+                "that are not markers at all (autofluorescence, blanks, empty "
+                "cycles) can be dropped with --exclude-marker. Re-run with "
+                "--allow-novel-defaults to accept default stats instead."
             )
             sys.exit(1)
-
-    if args.marker_report:
-        write_marker_report(
-            args.marker_report, args.tiff, channel_names, markers, applied, report_extra
-        )
 
     # --- extract -----------------------------------------------------------
     if not features:
@@ -263,7 +321,8 @@ def main():
     )
     log(
         f"Extracting {len(dataset)} cell patches "
-        f"(patch={args.patch_size}, isolate={args.isolate}, batch={args.batch_size})"
+        f"(patch={args.patch_size}, channels={len(reader.channels)}, "
+        f"isolate={args.isolate}, batch={args.batch_size})"
     )
     embeddings = extract(
         model,

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -316,6 +316,11 @@ process {
                     "--max-value ${params.kronos_max_value}" : null,
                 params.containsKey('kronos_marker_mapping') && params.kronos_marker_mapping ?
                     "--marker-mapping '${params.kronos_marker_mapping}'" : null,
+                // Each name is single quoted, unlike the EXTRACTMARKERS idiom above:
+                // panel channels contain spaces ('Collagen 4', 'Pan CK'). A name
+                // containing a single quote is not representable and is not handled.
+                params.containsKey('kronos_exclude_markers') && params.kronos_exclude_markers ?
+                    params.kronos_exclude_markers.split(',').collect { marker -> marker.trim() }.findAll { marker -> marker }.collect { marker -> "--exclude-marker '${marker}'" }.join(' ') : null,
                 params.containsKey('kronos_isolate_cell') && !params.kronos_isolate_cell ?
                     "--no-isolate-cell" : null,
                 params.containsKey('kronos_allow_novel_defaults') && params.kronos_allow_novel_defaults ?

--- a/docs/output.md
+++ b/docs/output.md
@@ -67,8 +67,11 @@ When `enable_kronos=true`:
   every cell. This is the **only** embedding artefact: the separate CSV that
   earlier versions wrote held the same vectors twice, so it has been dropped.
 - `kronos2embeddings/sample_marker_report.txt` -- per-channel record of the name
-  given to KRONOS2, any mappings applied, and any markers outside the model's
-  vocabulary.
+  given to KRONOS2, any mappings applied, any channels withheld with
+  `kronos_exclude_markers`, and any markers outside the model's vocabulary. The
+  header gives the embedded/not-shown split, so the number of channels the model
+  actually saw is on the first line. It is written even when the run then fails
+  on an unmatched marker, because that is when it is most useful.
 
 Embedding row _i_ corresponds to cell feature _i_ in the input GeoJSON, so the
 join is exact by construction. Re-running clears any previous `kronos_emb_*`

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -663,6 +663,42 @@ KRONOS2's **only** alias mechanism. The samplesheet's `nuclear_channel` is used
 automatically, so a slide stained with `DRAQ5` or `Hoechst2` still receives DAPI
 statistics.
 
+#### Channels that are not markers
+
+Some channels carry no biology at all -- autofluorescence, a blank, an empty
+cycle. No mapping can resolve those, and `kronos_allow_novel_defaults` is the
+wrong instrument because it still _feeds_ the channel to the model, normalised
+with default statistics. Withhold it instead:
+
+```bash
+--kronos_exclude_markers 'Autofluorescence'
+```
+
+**This affects the embedding step and nothing else.** The channel is simply never
+read by KRONOS2, so it contributes nothing to the embedding -- but it stays in
+the image, remains available to segmentation and every other process, and keeps
+whatever intensity measurements CELLMEASUREMENT wrote for it in the GeoJSON.
+Nothing is deleted from your data. Contrast `remove_markers`, which really does
+strip channels out of the background-subtracted image.
+
+Names are comma separated, case sensitive, and matched against the image's own
+channel names **before** any mapping is applied -- so name `Autofluorescence`,
+not whatever you might have mapped it to. A name matching no channel fails the
+run and lists the channels that are present, and the nuclear channel cannot be
+withheld because it is the model's `preferred_dapi`. Every withheld channel is
+recorded in `_marker_report.txt`.
+
+Two things to watch:
+
+- KRONOS2 attends across the whole channel set, so excluding one channel changes
+  the embedding of every _other_ channel too. Keep the exclusion list constant
+  across a cohort; embeddings computed from different channel sets are not
+  comparable.
+- On the background-subtraction paths KRONOS2 receives the **post-backsub**
+  image, so `remove_markers` has already been applied to it. The two options
+  therefore operate on different channel lists, and naming the same channel in
+  both makes the KRONOS2 run fail with "no such channel".
+
 #### KRONOS2 embedding parameters
 
 | Parameter Name                | Description                                                                                                                                                                             |
@@ -674,6 +710,7 @@ statistics.
 | `kronos_num_workers`          | PyTorch DataLoader worker processes (default: `4`).                                                                                                                                     |
 | `kronos_max_value`            | Override the intensity divisor. Unset (default) derives it from the image dtype -- `uint8`=255, `uint16`=65535, float=400 -- matching KRONOS2's own scaling factor.                     |
 | `kronos_marker_mapping`       | JSON file or inline JSON mapping channel names onto KRONOS2 vocabulary names (default: `null`).                                                                                         |
+| `kronos_exclude_markers`      | Comma-separated channels not shown to KRONOS2, so they contribute nothing to the embedding, e.g. `Autofluorescence` (default: `null`). The image and all other outputs are untouched.   |
 | `kronos_nuclear_marker`       | Override the nuclear stain used as `preferred_dapi`. Defaults to the samplesheet's `nuclear_channel`.                                                                                   |
 | `kronos_isolate_cell`         | Zero pixels outside the target cell so each embedding describes that cell rather than its surrounding neighbourhood (default: `true`).                                                  |
 | `kronos_allow_novel_defaults` | Proceed when markers fall outside the vocabulary, accepting default normalisation stats (default: `false`).                                                                             |

--- a/modules/local/kronos2embeddings/meta.yml
+++ b/modules/local/kronos2embeddings/meta.yml
@@ -69,7 +69,8 @@ output:
           type: file
           description: |
             Per-channel record of the name given to KRONOS2, any mappings
-            applied, and any markers outside the model's vocabulary.
+            applied, any channels excluded from the embedding, and any markers
+            outside the model's vocabulary.
           pattern: "*_marker_report.txt"
   - versions:
       - versions.yml:

--- a/modules/local/kronos2embeddings/tests/main.nf.test
+++ b/modules/local/kronos2embeddings/tests/main.nf.test
@@ -1,0 +1,73 @@
+nextflow_process {
+
+    name "Test Process KRONOS2EMBEDDINGS"
+    script "../main.nf"
+    process "KRONOS2EMBEDDINGS"
+
+    tag "modules"
+    tag "modules_local"
+    tag "kronos2embeddings"
+
+    // Stub only. A real run needs the gated KRONOS2 snapshot (KRONOS2_MODEL_DIR)
+    // and a GPU, neither of which CI has -- see conf/test_mesmer_kronos2.config.
+    // These cover the process contract and its output declarations; the channel
+    // and marker logic is covered by tests/python/test_kronos2_common.py.
+
+    test("kronos2embeddings - stub") {
+
+        options "-stub"
+
+        when {
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file('${projectDir}/tests/data/comet/synthetic_multichannel.tif'),
+                    file('${projectDir}/tests/data/comet/synthetic_multichannel.tif'),
+                    'DAPI'
+                ]
+                input[1] = file('${projectDir}/tests/data/comet')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+    test("kronos2embeddings - stub - exclude markers") {
+
+        options "-stub"
+
+        when {
+            params {
+                kronos_exclude_markers = 'TRITC'
+            }
+            process {
+                """
+                input[0] = [
+                    [ id:'test' ], // meta map
+                    file('${projectDir}/tests/data/comet/synthetic_multichannel.tif'),
+                    file('${projectDir}/tests/data/comet/synthetic_multichannel.tif'),
+                    'DAPI'
+                ]
+                input[1] = file('${projectDir}/tests/data/comet')
+                """
+            }
+        }
+
+        then {
+            assertAll(
+                { assert process.success },
+                { assert snapshot(process.out).match() }
+            )
+        }
+
+    }
+
+}

--- a/nextflow.config
+++ b/nextflow.config
@@ -139,6 +139,14 @@ params {
     // no alias or fuzzy step, so naming variants ("Collagen 4", "Cytokeritin")
     // must be mapped onto vocabulary names here or they take default stats.
     kronos_marker_mapping        = null
+    // Channels not to show KRONOS2, so they contribute nothing to the
+    // embedding. Comma separated and case sensitive, matched on the image's own
+    // channel names before any mapping. Scoped to this step: the channel stays
+    // in the image and keeps its measurements. For channels that are not
+    // markers -- autofluorescence, blanks, empty cycles -- which no mapping can
+    // resolve. Contrast kronos_allow_novel_defaults, which still FEEDS such a
+    // channel to the model, normalised with default stats.
+    kronos_exclude_markers       = null
     // Channel to treat as the nuclear stain. This is the model's ONLY alias
     // mechanism, so a DRAQ5/Hoechst slide needs it to receive DAPI stats.
     // null falls back to the samplesheet's nuclear_channel.

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -387,6 +387,12 @@
                     "fa_icon": "fas fa-exchange-alt",
                     "help_text": "Provide a JSON string like '{\"CD3e\": \"CD3E\", \"PanCK\": \"PANCK\"}' to manually resolve marker name mismatches between your image channels and the KRONOS metadata. KRONOS performs case-insensitive matching automatically, so only provide mappings for markers that truly differ in name."
                 },
+                "kronos_exclude_markers": {
+                    "type": "string",
+                    "description": "Comma-separated list of channels not to show KRONOS2, so they contribute nothing to the embedding, e.g. 'Autofluorescence'. Case sensitive, and matched against the image's own channel names before any marker mapping is applied.",
+                    "fa_icon": "fas fa-eye-slash",
+                    "help_text": "Scoped to the embedding step alone: the channel is simply never read, so it stays in the image, remains available to every other process, and keeps any intensity measurements CELLMEASUREMENT wrote for it. Nothing is deleted. Use it for channels that are not markers at all -- autofluorescence, blanks, empty cycles -- where no mapping can help. Contrast `kronos_allow_novel_defaults`, which still feeds an out-of-vocabulary channel to the model, normalised with default statistics. A name matching no channel fails the run and lists the channels that are present, and the nuclear channel cannot be skipped because it is the model's `preferred_dapi`. KRONOS2 attends across the whole channel set, so changing this list changes every cell's embedding -- hold it constant across a cohort."
+                },
                 "kronos_nuclear_marker": {
                     "type": "string",
                     "description": "Channel to treat as the nuclear stain. This is the model's only marker-alias mechanism, so a DRAQ5/Hoechst slide needs it to receive DAPI stats. Defaults to the samplesheet nuclear_channel.",

--- a/tests/python/test_kronos2_common.py
+++ b/tests/python/test_kronos2_common.py
@@ -1,0 +1,289 @@
+"""Unit tests for the channel-handling half of ``bin/kronos2_common.py``.
+
+These cover the code that decides *which pixels get which marker name* -- channel
+naming, exclusion, the windowed reader, and the marker report. That is worth
+pinning because its failure mode is silent: the run completes, the channel counts
+look right, and the embeddings are wrong.
+
+Pure python -- no torch, no GPU, no model weights.
+"""
+
+import numpy as np
+import pytest
+import tifffile
+
+from kronos2_common import (
+    ChannelReader,
+    apply_marker_mapping,
+    channel_layout,
+    get_channel_names,
+    select_channels,
+    write_marker_report,
+)
+
+PANEL = ["DAPI", "CD8", "TCR", "GrB", "HLA-DR", "PD-1", "Pan-CK", "Autofluorescence"]
+
+
+# ----------------------------------------------------------------------------
+# fixtures: the two OME-TIFF layouts
+# ----------------------------------------------------------------------------
+
+
+def _plane(value, size=16):
+    """A 2D plane whose every pixel is ``value``, so channels are separable."""
+    return np.full((size, size), value, dtype=np.uint16)
+
+
+@pytest.fixture
+def stacked_tiff(tmp_path):
+    """The usual layout: one CYX series holding every channel."""
+    path = tmp_path / "stacked.ome.tif"
+    data = np.stack([_plane(i + 1) for i in range(len(PANEL))])
+    tifffile.imwrite(
+        path, data, metadata={"axes": "CYX", "Channel": {"Name": PANEL}}
+    )
+    return path
+
+
+@pytest.fixture
+def split_tiff(tmp_path):
+    """Each channel in its own 2D series -- the layout that broadcast DAPI.
+
+    Written the way the inForm unmixing export writes it: a separate,
+    non-contiguous series per channel.
+    """
+    path = tmp_path / "split.ome.tif"
+    with tifffile.TiffWriter(path, ome=True) as writer:
+        for i, name in enumerate(PANEL):
+            writer.write(
+                _plane(i + 1),
+                contiguous=False,
+                metadata={"axes": "YX", "Channel": {"Name": name}},
+            )
+    return path
+
+
+# ----------------------------------------------------------------------------
+# select_channels
+# ----------------------------------------------------------------------------
+
+
+def test_no_exclusion_keeps_every_channel_in_order():
+    keep, kept, dropped = select_channels(PANEL)
+    assert keep == list(range(len(PANEL)))
+    assert kept == PANEL
+    assert dropped == []
+
+
+def test_excluding_the_last_channel():
+    keep, kept, dropped = select_channels(PANEL, ["Autofluorescence"])
+    assert keep == [0, 1, 2, 3, 4, 5, 6]
+    assert kept == PANEL[:-1]
+    assert dropped == ["Autofluorescence"]
+
+
+def test_excluding_a_middle_channel_preserves_order_and_indices():
+    keep, kept, dropped = select_channels(PANEL, ["TCR"])
+    assert keep == [0, 1, 3, 4, 5, 6, 7]
+    assert kept == ["DAPI", "CD8", "GrB", "HLA-DR", "PD-1", "Pan-CK", "Autofluorescence"]
+    assert dropped == ["TCR"]
+
+
+def test_repeated_and_blank_entries_are_tolerated():
+    keep, kept, dropped = select_channels(PANEL, ["  TCR  ", "TCR", "", "   "])
+    assert kept == ["DAPI", "CD8", "GrB", "HLA-DR", "PD-1", "Pan-CK", "Autofluorescence"]
+    assert dropped == ["TCR"]
+    assert 2 not in keep
+
+
+def test_duplicate_channel_names_are_all_dropped():
+    names = ["DAPI", "Blank", "CD8", "Blank"]
+    keep, kept, dropped = select_channels(names, ["Blank"])
+    assert keep == [0, 2]
+    assert kept == ["DAPI", "CD8"]
+    assert dropped == ["Blank", "Blank"]
+
+
+def test_unknown_name_fails_and_lists_the_available_channels():
+    with pytest.raises(ValueError) as excinfo:
+        select_channels(PANEL, ["Autofluorecence"])
+    message = str(excinfo.value)
+    assert "Autofluorecence" in message
+    for name in PANEL:
+        assert name in message
+
+
+def test_matching_is_case_sensitive():
+    with pytest.raises(ValueError):
+        select_channels(PANEL, ["autofluorescence"])
+
+
+def test_the_nuclear_marker_cannot_be_excluded():
+    with pytest.raises(ValueError, match="preferred_dapi"):
+        select_channels(PANEL, ["DAPI"], protect="DAPI")
+
+
+def test_protect_does_not_block_other_channels():
+    _, kept, dropped = select_channels(PANEL, ["Autofluorescence"], protect="DAPI")
+    assert dropped == ["Autofluorescence"]
+    assert "DAPI" in kept
+
+
+def test_excluding_everything_fails():
+    with pytest.raises(ValueError, match="nothing to embed"):
+        select_channels(PANEL, list(PANEL))
+
+
+def test_kept_names_stay_aligned_with_the_mapped_marker_list():
+    """The invariant the model depends on: one marker name per kept channel."""
+    keep, kept, _ = select_channels(PANEL, ["Autofluorescence"])
+    markers, _ = apply_marker_mapping(kept, {"TCR": "TCR_B", "Pan-CK": "CYTOKERATIN"})
+    assert len(markers) == len(keep)
+
+
+# ----------------------------------------------------------------------------
+# channel naming and layout
+# ----------------------------------------------------------------------------
+
+
+def test_names_and_layout_of_a_stacked_image(stacked_tiff):
+    assert get_channel_names(stacked_tiff) == PANEL
+    with tifffile.TiffFile(stacked_tiff) as tif:
+        assert channel_layout(tif) == ("stacked", len(PANEL))
+
+
+def test_names_and_layout_of_a_split_image(split_tiff):
+    """The regression: 8 one-channel series must count as 8 channels, not 1."""
+    with tifffile.TiffFile(split_tiff) as tif:
+        assert channel_layout(tif) == ("split", len(PANEL))
+    assert len(get_channel_names(split_tiff)) == len(PANEL)
+
+
+def test_an_unnamed_channel_gets_a_synthesised_name(tmp_path):
+    """Names must stay positional; dropping one would shift every later marker."""
+    path = tmp_path / "unnamed.ome.tif"
+    data = np.stack([_plane(i + 1) for i in range(3)])
+    tifffile.imwrite(
+        path, data, metadata={"axes": "CYX", "Channel": {"Name": ["DAPI", "", "CD8"]}}
+    )
+    names = get_channel_names(path)
+    assert len(names) == 3
+    assert names[0] == "DAPI"
+    assert names[2] == "CD8"
+    assert names[1]
+
+
+# ----------------------------------------------------------------------------
+# ChannelReader
+# ----------------------------------------------------------------------------
+
+
+def _window(reader):
+    return reader.read_window(0, 4, 0, 4)
+
+
+def test_stacked_reader_returns_the_requested_channels(stacked_tiff):
+    reader = ChannelReader(stacked_tiff, [0, 2, 5])
+    try:
+        window = _window(reader)
+        assert window.shape == (3, 4, 4)
+        assert [int(window[i].flat[0]) for i in range(3)] == [1, 3, 6]
+    finally:
+        reader.close()
+
+
+def test_split_reader_returns_distinct_channels(split_tiff):
+    """Before the fix this returned one channel, broadcast over all of them."""
+    reader = ChannelReader(split_tiff, list(range(len(PANEL))))
+    try:
+        assert reader.layout == "split"
+        assert reader.n_channels == len(PANEL)
+        window = _window(reader)
+        assert window.shape == (len(PANEL), 4, 4)
+        assert [int(window[i].flat[0]) for i in range(len(PANEL))] == list(
+            range(1, len(PANEL) + 1)
+        )
+    finally:
+        reader.close()
+
+
+def test_split_reader_honours_a_channel_subset(split_tiff):
+    keep, _, _ = select_channels(PANEL, ["Autofluorescence"])
+    reader = ChannelReader(split_tiff, keep)
+    try:
+        window = _window(reader)
+        assert window.shape == (7, 4, 4)
+        # Channel 8 (value 8) is the excluded one and must not appear.
+        assert 8 not in {int(window[i].flat[0]) for i in range(7)}
+    finally:
+        reader.close()
+
+
+def test_reader_refuses_to_return_too_few_channels(split_tiff, monkeypatch):
+    """The guard against silently broadcasting one channel across many markers."""
+    reader = ChannelReader(split_tiff, [0, 1, 2])
+    try:
+        monkeypatch.setattr(
+            reader, "_read_window", lambda *_: np.zeros((1, 4, 4), dtype=np.uint16)
+        )
+        with pytest.raises(ValueError, match="refusing to broadcast"):
+            _window(reader)
+    finally:
+        reader.close()
+
+
+# ----------------------------------------------------------------------------
+# marker report
+# ----------------------------------------------------------------------------
+
+
+def test_report_without_exclusion_is_unchanged(tmp_path):
+    """keep_indices=None must reproduce the pre-exclusion report exactly."""
+    path = tmp_path / "report.txt"
+    markers, applied = apply_marker_mapping(PANEL, {"TCR": "TCR_B"})
+    write_marker_report(path, "img.ome.tif", PANEL, markers, applied)
+    text = path.read_text()
+
+    assert f"Channels: {len(PANEL)}\n" in text
+    assert "excluded" not in text
+    assert "  TCR -> TCR_B  (mapped)\n" in text
+    assert "  DAPI -> DAPI\n" in text
+    assert "\nMappings applied via --marker-mapping:\n  TCR -> TCR_B\n" in text
+
+
+def test_report_records_excluded_channels(tmp_path):
+    path = tmp_path / "report.txt"
+    keep, kept, _ = select_channels(PANEL, ["Autofluorescence"])
+    markers, applied = apply_marker_mapping(kept, {"TCR": "TCR_B"})
+    write_marker_report(
+        path, "img.ome.tif", PANEL, markers, applied, keep_indices=keep
+    )
+    text = path.read_text()
+
+    assert "Channels: 8 (7 embedded, 1 not shown)" in text
+    assert "  Autofluorescence -> (not shown to KRONOS2)\n" in text
+    assert "still present in the image" in text
+    assert "\n  Autofluorescence\n" in text
+    assert "  TCR -> TCR_B  (mapped)\n" in text
+
+
+def test_report_attributes_rows_by_index_not_name(tmp_path):
+    """Duplicate channel names must not mis-attribute a row."""
+    path = tmp_path / "report.txt"
+    names = ["DAPI", "Blank", "CD8", "Blank"]
+    keep, kept, _ = select_channels(names, ["Blank"])
+    markers, applied = apply_marker_mapping(kept, {})
+    write_marker_report(path, "img.ome.tif", names, markers, applied, keep_indices=keep)
+    text = path.read_text()
+
+    assert text.count("Blank -> (not shown to KRONOS2)") == 2
+    assert "  DAPI -> DAPI\n" in text
+    assert "  CD8 -> CD8\n" in text
+
+
+def test_report_carries_extra_lines(tmp_path):
+    path = tmp_path / "report.txt"
+    write_marker_report(
+        path, "img.ome.tif", PANEL, PANEL, [], ["Novel markers (default stats used):"]
+    )
+    assert "Novel markers (default stats used):" in path.read_text()


### PR DESCRIPTION
## Summary

Two changes, one of which is a silent correctness bug worth reading first.

### 1. `kronos_exclude_markers` — withhold non-marker channels from KRONOS2

A COMET panel's `Autofluorescence` channel is not a marker and is not in KRONOS2's
288-marker vocabulary, so the run fails:

```
ERROR: 1 of 8 markers are outside KRONOS2's vocabulary and will use DEFAULT
normalisation stats: ['Autofluorescence']
```

There was no way to say "don't embed this channel". `--marker-mapping` only renames,
and `--allow-novel-defaults` still *feeds* the channel to the model, normalised with
default statistics — the opposite of what is wanted for a channel carrying no biology.

```bash
--kronos_exclude_markers 'Autofluorescence'
```

**Scoped to the embedding step; nothing is deleted.** A withheld channel is simply
never read, so it stays in the image, remains available to segmentation and every
other process, and keeps whatever intensity measurements CELLMEASUREMENT wrote for it
in the GeoJSON. This is deliberately *unlike* `remove_markers`, which does strip
channels out of the background-subtracted image — the parameter shape is borrowed from
it, the blast radius is not, and the log line, marker report and docs all say "not
shown to KRONOS2" rather than "removed" so the distinction is not mistakable.

Names are comma separated and case sensitive, matched against the image's own channel
names *before* any mapping. A name matching nothing fails the run and lists the
channels that are present; the nuclear channel cannot be withheld because it is the
model's `preferred_dapi`.

### 2. :warning: KRONOS2 embedded one channel under every marker's name

Found while making channel indices load-bearing for the above.

On OME-TIFFs that store each channel as its own 2D series, `ChannelReader` sized itself
from `series[0]` alone, so an 8-series image read as **1** channel — while
`CellPatchDataset` still sized the patch buffer from the 8-name marker list. NumPy then
broadcast that single channel across all eight slots.

The run completed, logged `Found 8 channels`, and produced 768-d vectors computed from
eight copies of DAPI. No error, no warning. The tell in the log is `Found 8 channels`
on one line and `image 1x27454x26980` a few lines later.

Confirmed on the COMET `_fixed` images (inForm unmixing export): every one of the 8
"markers" came back byte-identical to DAPI. **Embeddings produced from such images by
earlier versions are invalid and need regenerating.**

Now: the layout is detected once by `channel_layout()` and shared between the name list
and the pixel reader; each channel is read from its own series via its own zarr store;
`read_window` refuses to return fewer channels than it was asked for, so this class of
bug cannot recur silently; and the run fails outright if the channel-name count and the
image's channel count disagree.

Also fixed in passing: a channel whose OME `Channel` element carried neither `Name` nor
`ID` was dropped from the name list but not from the image, sliding every later marker
onto the wrong channel. Names are now built positionally, one per channel always.

### Marker report

Gains the embedded/not-shown split and names withheld channels in place. It is now
written *before* the novel-marker gate can exit — a failing run is exactly when you
need it, since it lists the channel names to map or withhold.

```
Channels: 8 (7 embedded, 1 not shown)

Channel -> name given to KRONOS2
  DAPI -> DAPI
  TCR -> TCR_B  (mapped)
  ...
  Autofluorescence -> (not shown to KRONOS2)

Withheld from KRONOS2 via --exclude-marker (still present in the image):
  Autofluorescence
```

## Testing

`tests/python/test_kronos2_common.py` is the first module under the `tests/python/`
scaffold, which had a `conftest.py` and no tests since the cellmeasurement extraction.
22 tests covering channel naming, selection, the reader and the report. Pure python —
no torch, no GPU, no gated weights — so a `pytest` job has been added to the linting
workflow and it actually runs in CI.

The split-layout test is a genuine regression guard: against the pre-fix code its
fixture returns eight identical channels, against the fix it returns eight distinct
ones.

Also adds a stub `nf-test` for `KRONOS2EMBEDDINGS`, which had none — the KRONOS1 test
was deleted in the v2 migration and never replaced.

Verified locally beyond the unit tests:

- Reader and channel selection against the real 8-channel COMET image — patches are now
  `(7, 64, 64)` with per-channel values matching the raw file exactly.
- All four failure paths exit 1 with actionable messages (unknown name, wrong case,
  nuclear channel, everything withheld).
- The Groovy `ext.args` expansion quotes names containing spaces (`'Collagen 4'`),
  trims whitespace and drops empty entries from a trailing comma.
- `pre-commit run --all-files` passes.

**Not run:** the model forward itself, which needs the gated snapshot and a GPU. The
`preprocess` contract was verified by reading the model source — it builds its stats
list from `marker_names` and broadcasts, so it is channel-count agnostic.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/wehi-soda-hub/sp_segment/tree/master/.github/CONTRIBUTING.md) — n/a, no new tool
- [ ] Make sure your code lints (`nf-core pipelines lint`) — `nf-core` not available locally; `pre-commit` passes
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`) — not run locally (no container engine on the login node)
- [ ] Check for unexpected warnings in debug mode
- [x] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [x] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated — n/a, it delegates the parameter list to `docs/usage.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
